### PR TITLE
fix: update to latest slack-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@adobe/spacecat-shared-data-access": "1.13.2",
         "@adobe/spacecat-shared-http-utils": "1.1.3",
         "@adobe/spacecat-shared-rum-api-client": "1.4.3",
-        "@adobe/spacecat-shared-slack-client": "1.0.1",
+        "@adobe/spacecat-shared-slack-client": "1.1.0",
         "@adobe/spacecat-shared-utils": "1.7.4",
         "comma-number": "2.1.0",
         "human-format": "1.2.0"
@@ -822,9 +822,9 @@
       "integrity": "sha512-UMRJa3RZImvqkFSmtCJ1u8zFbLZNi8wtaf+whJAA6xksaW/sGb0iTFqIc78Aui7aS3FnKLjpCjiT2KB7ejNyDQ=="
     },
     "node_modules/@adobe/spacecat-shared-slack-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-slack-client/-/spacecat-shared-slack-client-1.0.1.tgz",
-      "integrity": "sha512-C5nPHPvFW1Z9ROK8+RtZfQrE0SySCLmHohToS8tcHvs7ipAWGGcBFInzpmIv/a2EsphlHbLJmV1o02CXT0L5hA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-slack-client/-/spacecat-shared-slack-client-1.1.0.tgz",
+      "integrity": "sha512-9YZfI+HqgcVd5kxxfC09ARPF4Ay9tXH2aJATAKXUeNZZW6b6Mvk43zdeGRQXJZXRQSEWAPoLvOmW3FkgR4EDzQ==",
       "dependencies": {
         "@adobe/helix-universal": "4.4.1",
         "@adobe/spacecat-shared-utils": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@adobe/spacecat-shared-http-utils": "1.1.3",
     "@adobe/spacecat-shared-utils": "1.7.4",
     "@adobe/spacecat-shared-data-access": "1.13.2",
-    "@adobe/spacecat-shared-slack-client": "1.0.1",
+    "@adobe/spacecat-shared-slack-client": "1.1.0",
     "comma-number": "2.1.0",
     "human-format": "1.2.0"
   },

--- a/src/digest/handler-external.js
+++ b/src/digest/handler-external.js
@@ -11,7 +11,7 @@
  */
 
 import { internalServerError, noContent } from '@adobe/spacecat-shared-http-utils';
-import { SlackClient, SLACK_TARGETS } from '@adobe/spacecat-shared-slack-client';
+import { BaseSlackClient, SLACK_TARGETS } from '@adobe/spacecat-shared-slack-client';
 
 import {
   getSlackContextForAlert, hasAlertConfig, isDigestReport,
@@ -29,7 +29,7 @@ export default async function externalDigestHandler(
 
   const organizations = await dataAccess.getOrganizations();
   let sentInitialMessage = false;
-  const slackClient = SlackClient.createFrom(context, SLACK_TARGETS.ADOBE_EXTERNAL);
+  const slackClient = BaseSlackClient.createFrom(context, SLACK_TARGETS.WORKSPACE_EXTERNAL);
 
   for (const organization of organizations) {
     const orgConfig = organization.getConfig();

--- a/src/digest/handler-internal.js
+++ b/src/digest/handler-internal.js
@@ -11,7 +11,7 @@
  */
 
 import { internalServerError, noContent } from '@adobe/spacecat-shared-http-utils';
-import { SLACK_TARGETS, SlackClient } from '@adobe/spacecat-shared-slack-client';
+import { BaseSlackClient, SLACK_TARGETS } from '@adobe/spacecat-shared-slack-client';
 import { processLatestAudit } from '../support/audits.js';
 
 export default async function internalDigestHandler(
@@ -25,7 +25,7 @@ export default async function internalDigestHandler(
     env: { AUDIT_REPORT_SLACK_CHANNEL_ID: slackChannelId }, dataAccess, log,
   } = context;
   let sentInitialMessage = false;
-  const slackClient = SlackClient.createFrom(context, SLACK_TARGETS.ADOBE_INTERNAL);
+  const slackClient = BaseSlackClient.createFrom(context, SLACK_TARGETS.WORKSPACE_INTERNAL);
   let slackContext = {};
 
   const sites = await dataAccess.getSitesWithLatestAudit(type, false);

--- a/test/notfound/handler-external.test.js
+++ b/test/notfound/handler-external.test.js
@@ -136,7 +136,7 @@ describe('not found external handler', () => {
     const orgChannel = 'channelOrg1';
     const siteChannel = 'channelSite2';
     context.slackClients = {
-      ADOBE_EXTERNAL: { postMessage: sandbox.stub().resolves({ channel: orgChannel, threadId: 'thread-1' }) },
+      WORKSPACE_EXTERNAL_STANDARD: { postMessage: sandbox.stub().resolves({ channel: orgChannel, threadId: 'thread-1' }) },
     };
     const initialBlocks = build404InitialSlackMessage(['slackOrgId1']);
     const blocksOrg = build404SlackMessage(
@@ -151,15 +151,15 @@ describe('not found external handler', () => {
       ['slackSiteId2'],
     );
     const resp = await notFoundExternalDigestHandler({}, context);
-    expect(context.slackClients.ADOBE_EXTERNAL.postMessage).calledWith(
+    expect(context.slackClients.WORKSPACE_EXTERNAL_STANDARD.postMessage).calledWith(
       ({ blocks: initialBlocks, channel: orgChannel }),
     );
-    expect(context.slackClients.ADOBE_EXTERNAL.postMessage).calledWith(
+    expect(context.slackClients.WORKSPACE_EXTERNAL_STANDARD.postMessage).calledWith(
       {
         blocks: blocksOrg, channel: orgChannel, thread_ts: 'thread-1', unfurl_links: false,
       },
     );
-    expect(context.slackClients.ADOBE_EXTERNAL.postMessage).calledWith(
+    expect(context.slackClients.WORKSPACE_EXTERNAL_STANDARD.postMessage).calledWith(
       {
         blocks: blocksSite, channel: siteChannel, mentions: ['slackSiteId2'], unfurl_links: false,
       },
@@ -169,7 +169,7 @@ describe('not found external handler', () => {
 
   it('builds no message when there is no audit', async () => {
     context.slackClients = {
-      ADOBE_EXTERNAL: { postMessage: sandbox.stub().rejects(new Error('error')) },
+      WORKSPACE_EXTERNAL_STANDARD: { postMessage: sandbox.stub().rejects(new Error('error')) },
     };
     const noAuditContext = { ...context };
     noAuditContext.dataAccess = { ...context.dataAccess };
@@ -180,7 +180,7 @@ describe('not found external handler', () => {
 
   it('returns 500 if the initial slack api fails', async () => {
     context.slackClients = {
-      ADOBE_EXTERNAL: { postMessage: sandbox.stub().rejects(new Error('error')) },
+      WORKSPACE_EXTERNAL_STANDARD: { postMessage: sandbox.stub().rejects(new Error('error')) },
     };
     const resp = await notFoundExternalDigestHandler({}, context);
     expect(resp.status).to.equal(500);
@@ -192,9 +192,9 @@ describe('not found external handler', () => {
       create404Backlink: sandbox.stub().resolves(backlink),
     };
     context.slackClients = {
-      ADOBE_EXTERNAL: { postMessage: sandbox.stub().onFirstCall().resolves({ channel, ts: 'ts-1' }) },
+      WORKSPACE_EXTERNAL_STANDARD: { postMessage: sandbox.stub().onFirstCall().resolves({ channel, ts: 'ts-1' }) },
     };
-    context.slackClients.ADOBE_EXTERNAL.postMessage.onSecondCall().rejects(new Error('error'));
+    context.slackClients.WORKSPACE_EXTERNAL_STANDARD.postMessage.onSecondCall().rejects(new Error('error'));
 
     const resp = await notFoundExternalDigestHandler({}, context);
     expect(resp.status).to.equal(204);
@@ -206,7 +206,7 @@ describe('not found external handler', () => {
       create404Backlink: sandbox.stub().rejects('error'),
     };
     context.slackClients = {
-      ADOBE_EXTERNAL: { postMessage: sandbox.stub().resolves({ channel, ts: 'ts-1' }) },
+      WORKSPACE_EXTERNAL_STANDARD: { postMessage: sandbox.stub().resolves({ channel, ts: 'ts-1' }) },
     };
     const siteContext = { ...context };
     const newOrgData = {

--- a/test/notfound/handler-internal.test.js
+++ b/test/notfound/handler-internal.test.js
@@ -87,7 +87,7 @@ describe('not found internal handler', () => {
       getDomainList: sandbox.stub().resolves(['abcd.com']),
     };
     context.slackClients = {
-      ADOBE_INTERNAL: {
+      WORKSPACE_INTERNAL_STANDARD: {
         postMessage: sandbox.stub().resolves(
           { channelId: channel, threadId: thread },
         ),
@@ -103,13 +103,13 @@ describe('not found internal handler', () => {
       getDomainList: sandbox.stub().resolves(['abcd.com']),
     };
     context.slackClients = {
-      ADOBE_INTERNAL: {
+      WORKSPACE_INTERNAL_STANDARD: {
         postMessage: sandbox.stub().onFirstCall().resolves(
           { channelId: channel, threadId: thread },
         ),
       },
     };
-    context.slackClients.ADOBE_INTERNAL.postMessage.onSecondCall().rejects(new Error('error'));
+    context.slackClients.WORKSPACE_INTERNAL_STANDARD.postMessage.onSecondCall().rejects(new Error('error'));
     const resp = await notFoundInternalDigestHandler({}, context);
     expect(resp.status).to.equal(204);
   });
@@ -119,7 +119,7 @@ describe('not found internal handler', () => {
       getDomainList: sandbox.stub().resolves(['abcd.com']),
     };
     context.slackClients = {
-      ADOBE_INTERNAL: { postMessage: sandbox.stub().onFirstCall().rejects(new Error('error')) },
+      WORKSPACE_INTERNAL_STANDARD: { postMessage: sandbox.stub().onFirstCall().rejects(new Error('error')) },
     };
     const resp = await notFoundInternalDigestHandler({}, context);
     expect(resp.status).to.equal(500);


### PR DESCRIPTION
Updating to latest slack client as per https://github.com/adobe/spacecat-shared/pull/124

I updated the CI secrets as follows:
```
    "SLACK_OPS_CHANNEL_WORKSPACE_EXTERNAL": "****",
    "SLACK_OPS_CHANNEL_WORKSPACE_INTERNAL": "****",
    "SLACK_TOKEN_WORKSPACE_EXTERNAL": "****",
    "SLACK_TOKEN_WORKSPACE_INTERNAL": "****",
```