### PR TITLE
fix: error handling and more tests for internal and external handlers

### DIFF
--- a/src/digest/handler-external.js
+++ b/src/digest/handler-external.js
@@ -57,7 +57,7 @@ export default async function externalDigestHandler(
               slackContext = await sendInitialMessage(slackClient, slackContext, INITIAL_MESSAGE);
               sentInitialMessage = true;
             } catch (e) {
-              log.error(`Failed to send initial Slack message. Reason: ${e.message}`);
+              log.error(`Failed to send initial Slack message for ${site.getBaseURL()} to ${JSON.stringify(slackContext)}. Reason: ${e.message}`);
               return internalServerError('Failed to send initial Slack message');
             }
           }
@@ -69,7 +69,7 @@ export default async function externalDigestHandler(
               message,
             });
           } catch (e) {
-            log.error(`Failed to send Slack message for ${site.getBaseURL()}. Reason: ${e.message}`);
+            log.error(`Failed to send Slack message for ${site.getBaseURL()} to ${JSON.stringify(slackContext)}. Reason: ${e.message}`);
           }
         }
       }

--- a/src/digest/handler-external.js
+++ b/src/digest/handler-external.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { internalServerError, noContent } from '@adobe/spacecat-shared-http-utils';
+import { noContent } from '@adobe/spacecat-shared-http-utils';
 import { BaseSlackClient, SLACK_TARGETS } from '@adobe/spacecat-shared-slack-client';
 
 import {
@@ -28,10 +28,10 @@ export default async function externalDigestHandler(
   const { dataAccess, log } = context;
 
   const organizations = await dataAccess.getOrganizations();
-  let sentInitialMessage = false;
   const slackClient = BaseSlackClient.createFrom(context, SLACK_TARGETS.WORKSPACE_EXTERNAL);
 
   for (const organization of organizations) {
+    let sentInitialMessage = false;
     const orgConfig = organization.getConfig();
     if (hasAlertConfig(orgConfig, type)) {
       const organizationId = organization.getId();
@@ -58,7 +58,6 @@ export default async function externalDigestHandler(
               sentInitialMessage = true;
             } catch (e) {
               log.error(`Failed to send initial Slack message for ${site.getBaseURL()} to ${JSON.stringify(slackContext)}. Reason: ${e.message}`);
-              return internalServerError('Failed to send initial Slack message');
             }
           }
           try {
@@ -75,5 +74,6 @@ export default async function externalDigestHandler(
       }
     }
   }
+
   return noContent();
 }

--- a/src/digest/handler-internal.js
+++ b/src/digest/handler-internal.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { internalServerError, noContent } from '@adobe/spacecat-shared-http-utils';
+import { noContent } from '@adobe/spacecat-shared-http-utils';
 import { BaseSlackClient, SLACK_TARGETS } from '@adobe/spacecat-shared-slack-client';
 import { sendInitialMessage } from '../support/slack.js';
 
@@ -43,8 +43,7 @@ export default async function internalDigestHandler(
           );
           sentInitialMessage = true;
         } catch (e) {
-          log.error(`Failed to send initial Slack message. Reason: ${e.message}`);
-          return internalServerError('Failed to send initial Slack message');
+          log.error(`Failed to send initial Slack message for ${site.getBaseURL()} to ${JSON.stringify(slackContext)}. Reason: ${e.message}`);
         }
       }
       try {
@@ -55,7 +54,7 @@ export default async function internalDigestHandler(
           message,
         });
       } catch (e) {
-        log.error(`Failed to send Slack message for ${site.getBaseURL()}. Reason: ${e.message}`);
+        log.error(`Failed to send Slack message for ${site.getBaseURL()} to ${JSON.stringify(slackContext)}. Reason: ${e.message}`);
       }
     }
   }

--- a/src/support/slack.js
+++ b/src/support/slack.js
@@ -45,7 +45,7 @@ export async function postSlackMessage(token, opts) {
     });
     respJson = await resp.json();
   } catch (e) {
-    throw new Error(`Failed to send slack message. ${resp ? `Status: ${resp.status}` : /* c8 ignore next  */ ''}`);
+    throw new Error(`Failed to send slack message on channel ${channel}. ${resp ? `Status: ${resp.status}` : /* c8 ignore next  */ ''}`);
   }
 
   if (!respJson.ok) {
@@ -102,7 +102,7 @@ export async function uploadSlackFile(token, opts) {
       fileUrl: responseJson.file.url_private,
     };
   } catch (e) {
-    throw new Error(`Failed to upload file to slack. Reason: ${e.message}`);
+    throw new Error(`Failed to upload file to slack: channel ${channel}, filename ${fileName}. Reason: ${e.message}`);
   }
 }
 

--- a/test/apex/handler.test.js
+++ b/test/apex/handler.test.js
@@ -173,6 +173,6 @@ describe('cwv handler', () => {
 
     const resp = await apex(message, context);
     expect(resp.status).to.equal(500);
-    expect(errorLogSpy).to.have.been.calledWith(`Failed to send Slack message for ${message.url}. Reason: Failed to send slack message. Status: 500`);
+    expect(errorLogSpy).to.have.been.calledWith(`Failed to send Slack message for ${message.url}. Reason: Failed to send slack message on channel ${channel}. Status: 500`);
   });
 });

--- a/test/cwv/handler.test.js
+++ b/test/cwv/handler.test.js
@@ -231,6 +231,6 @@ describe('cwv handler', () => {
     const resp = await cwv(message, context);
     expect(resp.status).to.equal(500);
     expect(warnLogSpy).to.have.been.calledWith(`Failed to get a backlink for ${message.auditContext.finalUrl}`);
-    expect(errorLogSpy).to.have.been.calledWith(`Failed to send Slack message for ${message.url}. Reason: Failed to send slack message. Status: 500`);
+    expect(errorLogSpy).to.have.been.calledWith(`Failed to send Slack message for ${message.url}. Reason: Failed to send slack message on channel ${channel}. Status: 500`);
   });
 });

--- a/test/digest/handler-external.test.js
+++ b/test/digest/handler-external.test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+
+import sinon from 'sinon';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import { BaseSlackClient } from '@adobe/spacecat-shared-slack-client';
+import externalDigestHandler from '../../src/digest/handler-external.js';
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+const sandbox = sinon.createSandbox();
+
+describe('external handler', () => {
+  let context;
+  let mockDataAccess;
+  let mockSlackClient;
+  const processLatestAudit = sandbox.stub();
+  const sendReport = sandbox.stub();
+
+  beforeEach('setup', () => {
+    mockDataAccess = {
+      getOrganizations: sandbox.stub(),
+      getSitesByOrganizationIDWithLatestAudits: sandbox.stub(),
+    };
+    mockSlackClient = {
+      postMessage: sandbox.stub().resolves(),
+    };
+    context = {
+      log: {
+        error: sandbox.stub(),
+      },
+      dataAccess: mockDataAccess,
+      slackClients: {
+        WORKSPACE_EXTERNAL_STANDARD: mockSlackClient,
+      },
+    };
+    sandbox.stub(BaseSlackClient, 'createFrom').returns(mockSlackClient);
+  });
+
+  afterEach('clean', () => {
+    sandbox.restore();
+  });
+
+  it('should skip if no organizations', async () => {
+    mockDataAccess.getOrganizations.resolves([]);
+
+    const response = await externalDigestHandler(context, 'type', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockDataAccess.getOrganizations).to.have.been.calledOnce;
+    expect(context.log.error).not.to.have.been.called;
+    expect(processLatestAudit).not.to.have.been.called;
+    expect(sendReport).not.to.have.been.called;
+  });
+
+  it('should skip the organization if it does not have an alert config', async () => {
+  });
+
+  it('should skip the organization if there are no sites for an organization', async () => {
+  });
+
+  it('should skip the site if it does not have any audits', async () => {
+  });
+
+  it('should skip the site if processLatestAudit function does not return any message', async () => {
+  });
+
+  it('should continue with the other sites/orgs when the dataAccess function throws an error for one of the sites/orgs', async () => {
+  });
+
+  it('should continue with the other sites/orgs when the sendInitialMessage function throws an error', async () => {
+  });
+
+  it('should continue with the other sites/orgs when the sendReport function throws an error', async () => {
+  });
+
+  it('should use slack in site config to send initial message and report when alert is byOrg false', async () => {
+  });
+
+  it('should use slack in org config to send initial message and report when alert is byOrg true', async () => {
+  });
+
+  it('should send initial message only once per each organization', async () => {
+  });
+
+  it('should pass message returned by processLatestAudit to sendReport', async () => {
+  });
+});

--- a/test/digest/handler-external.test.js
+++ b/test/digest/handler-external.test.js
@@ -16,6 +16,8 @@ import chai from 'chai';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import { BaseSlackClient } from '@adobe/spacecat-shared-slack-client';
+import { createSite } from '@adobe/spacecat-shared-data-access/src/models/site.js';
+import { createOrganization } from '@adobe/spacecat-shared-data-access/src/models/organization.js';
 import externalDigestHandler from '../../src/digest/handler-external.js';
 
 chai.use(sinonChai);
@@ -28,8 +30,201 @@ describe('external handler', () => {
   let context;
   let mockDataAccess;
   let mockSlackClient;
-  const processLatestAudit = sandbox.stub();
-  const sendReport = sandbox.stub();
+  let processLatestAudit = sandbox.stub();
+  let sendReport = sandbox.stub();
+
+  const orgByOrgTrue = createOrganization({
+    id: 'org-with-by-org-true',
+    name: 'org-with-by-org-true',
+    config: {
+      alerts: [
+        {
+          type: '404',
+          byOrg: true,
+        },
+        {
+          type: 'broken-backlinks',
+          byOrg: true,
+          mentions: [{
+            slack: [],
+          }],
+        },
+      ],
+      slack: {
+        channel: 'C06CNBHRH4D',
+      },
+    },
+  });
+  const org2ByOrgTrue = createOrganization({
+    id: 'org2-with-by-org-true',
+    name: 'org2-with-by-org-true',
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+          byOrg: true,
+        },
+      ],
+      slack: {
+        channel: 'C06CNBHRHM6',
+      },
+    },
+  });
+  const orgByOrgFalse = createOrganization({
+    id: 'org-with-by-org-false',
+    name: 'org-with-by-org-false',
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+          byOrg: false,
+        },
+      ],
+      slack: {},
+    },
+  });
+  const siteByOrgTrue = createSite({
+    id: 'site-with-alert-config-org-level',
+    baseURL: 'https://abcd.com',
+    organizationId: orgByOrgTrue.getId(),
+    config: {
+      alerts: [
+        {
+          type: '404',
+        },
+        {
+          type: 'broken-backlinks',
+        },
+      ],
+      slack: {},
+    },
+  });
+  siteByOrgTrue.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [
+          {
+            title: 'backlink title',
+            url_from: 'https://from.com/from-1',
+            url_to: 'https://www.abcd.com/to-1',
+          },
+          {
+            title: 'backlink title 2',
+            url_from: 'https://from.com/from-2',
+            url_to: 'https://www.abcd.com/to-2',
+          },
+        ],
+        finalUrl: 'www.abcd.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+  const site2ByOrgTrue = createSite({
+    id: 'site2-with-alert-config-org-level',
+    baseURL: 'https://xyz.com',
+    organizationId: orgByOrgTrue.getId(),
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+        },
+      ],
+      slack: {},
+    },
+  });
+  site2ByOrgTrue.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [],
+        finalUrl: 'xyz.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+  const site3ByOrgTrue = createSite({
+    id: 'site3-with-alert-config-org-level',
+    baseURL: 'https://test.com',
+    organizationId: org2ByOrgTrue.getId(),
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+        },
+      ],
+      slack: {},
+    },
+  });
+  site3ByOrgTrue.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [],
+        finalUrl: 'test.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+
+  const siteByOrgFalse = createSite({
+    id: 'site-with-alert-config-site-level',
+    baseURL: 'https://foo.bar.com',
+    organizationId: orgByOrgFalse.getId(),
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+          mentions: [
+            {
+              slack: [
+                '<@U04N8J8FL6H>',
+              ],
+            },
+          ],
+        },
+      ],
+      slack: {
+        channel: 'C06CNBHRH12',
+      },
+    },
+  });
+  siteByOrgFalse.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [
+          {
+            title: 'backlink title',
+            url_from: 'https://from.com/from-1',
+            url_to: 'https://foo.bar.com/to-1',
+          },
+        ],
+        finalUrl: 'foo.bar.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+  const site2ByOrgFalse = createSite({
+    id: 'site2-with-alert-config-site-level',
+    baseURL: 'https://bar.com',
+    organizationId: orgByOrgFalse.getId(),
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+        },
+      ],
+      slack: {
+        channel: 'C06CNBHRH21',
+      },
+    },
+  });
+  site2ByOrgFalse.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [],
+        finalUrl: 'bar.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
 
   beforeEach('setup', () => {
     mockDataAccess = {
@@ -37,7 +232,7 @@ describe('external handler', () => {
       getSitesByOrganizationIDWithLatestAudits: sandbox.stub(),
     };
     mockSlackClient = {
-      postMessage: sandbox.stub().resolves(),
+      postMessage: sandbox.stub(),
     };
     context = {
       log: {
@@ -49,6 +244,8 @@ describe('external handler', () => {
       },
     };
     sandbox.stub(BaseSlackClient, 'createFrom').returns(mockSlackClient);
+    processLatestAudit = sandbox.stub();
+    sendReport = sandbox.stub();
   });
 
   afterEach('clean', () => {
@@ -58,45 +255,291 @@ describe('external handler', () => {
   it('should skip if no organizations', async () => {
     mockDataAccess.getOrganizations.resolves([]);
 
-    const response = await externalDigestHandler(context, 'type', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+    const response = await externalDigestHandler(context, '404', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
 
     expect(response.status).to.equal(204);
     expect(mockDataAccess.getOrganizations).to.have.been.calledOnce;
-    expect(context.log.error).not.to.have.been.called;
     expect(processLatestAudit).not.to.have.been.called;
+    expect(mockSlackClient.postMessage).not.to.have.been.called;
     expect(sendReport).not.to.have.been.called;
+    expect(context.log.error).not.to.have.been.called;
   });
 
-  it('should skip the organization if it does not have an alert config', async () => {
+  it('should skip the organization if it does not have an alert config of matching type', async () => {
+    mockDataAccess.getOrganizations.resolves([{
+      getId: () => 'some-id',
+      getConfig: () => ({ alerts: [{ type: '404' }] }),
+    }]);
+
+    const response = await externalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockDataAccess.getOrganizations).to.have.been.calledOnce;
+    expect(processLatestAudit).not.to.have.been.called;
+    expect(mockSlackClient.postMessage).not.to.have.been.called;
+    expect(sendReport).not.to.have.been.called;
+    expect(context.log.error).not.to.have.been.called;
   });
 
   it('should skip the organization if there are no sites for an organization', async () => {
+    mockDataAccess.getOrganizations.resolves([{
+      getId: () => 'some-id',
+      getConfig: () => ({ alerts: [{ type: 'broken-backlinks' }] }),
+    }]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits.resolves([]);
+
+    const response = await externalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockDataAccess.getOrganizations).to.have.been.calledOnce;
+    expect(mockDataAccess.getSitesByOrganizationIDWithLatestAudits).to.have.been.calledOnceWith('some-id', 'broken-backlinks', false);
+    expect(processLatestAudit).not.to.have.been.called;
+    expect(mockSlackClient.postMessage).not.to.have.been.called;
+    expect(sendReport).not.to.have.been.called;
+    expect(context.log.error).not.to.have.been.called;
   });
 
   it('should skip the site if it does not have any audits', async () => {
+    mockDataAccess.getOrganizations.resolves([{
+      getId: () => 'some-id',
+      getConfig: () => ({ alerts: [{ type: 'broken-backlinks' }] }),
+    }]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits.resolves([{
+      getAudits: () => [],
+    }]);
+
+    const response = await externalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockDataAccess.getOrganizations).to.have.been.calledOnce;
+    expect(mockDataAccess.getSitesByOrganizationIDWithLatestAudits).to.have.been.calledOnceWith('some-id', 'broken-backlinks', false);
+    expect(processLatestAudit).not.to.have.been.called;
+    expect(mockSlackClient.postMessage).not.to.have.been.called;
+    expect(sendReport).not.to.have.been.called;
+    expect(context.log.error).not.to.have.been.called;
   });
 
   it('should skip the site if processLatestAudit function does not return any message', async () => {
-  });
+    mockDataAccess.getOrganizations.resolves([orgByOrgTrue]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits.resolves([siteByOrgTrue]);
+    processLatestAudit.withArgs(context, siteByOrgTrue, siteByOrgTrue.getAudits()).returns({});
 
-  it('should continue with the other sites/orgs when the dataAccess function throws an error for one of the sites/orgs', async () => {
+    const response = await externalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockDataAccess.getOrganizations).to.have.been.calledOnce;
+    expect(mockDataAccess.getSitesByOrganizationIDWithLatestAudits).to.have.been.calledOnceWith(orgByOrgTrue.getId(), 'broken-backlinks', false);
+    expect(mockSlackClient.postMessage).not.to.have.been.called;
+    expect(sendReport).not.to.have.been.called;
+    expect(context.log.error).not.to.have.been.called;
   });
 
   it('should continue with the other sites/orgs when the sendInitialMessage function throws an error', async () => {
+    mockDataAccess.getOrganizations.resolves([orgByOrgTrue, org2ByOrgTrue]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits.withArgs(orgByOrgTrue.getId(), 'broken-backlinks', false)
+      .resolves([siteByOrgTrue, site2ByOrgTrue]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits.withArgs(org2ByOrgTrue.getId(), 'broken-backlinks', false)
+      .resolves([site3ByOrgTrue]);
+    processLatestAudit.withArgs(context, siteByOrgTrue, siteByOrgTrue.getAudits())
+      .returns(siteByOrgTrue.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site2ByOrgTrue, site2ByOrgTrue.getAudits())
+      .returns(site2ByOrgTrue.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site3ByOrgTrue, site3ByOrgTrue.getAudits())
+      .returns(site3ByOrgTrue.getAudits()[0].state.auditResult);
+    mockSlackClient.postMessage.onFirstCall().rejects(new Error('Failed to send initial message'));
+    mockSlackClient.postMessage.onSecondCall().resolves({ threadId: 'thread-id' });
+    mockSlackClient.postMessage.onThirdCall().resolves({ threadId: 'thread-id' });
+
+    const response = await externalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockSlackClient.postMessage).to.have.been.calledThrice;
+    expect(mockSlackClient.postMessage).to.have.been.calledWith({
+      channel: orgByOrgTrue.getConfig().slack.channel,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: ' INITIAL_MESSAGE',
+          },
+        },
+      ],
+    });
+    expect(mockSlackClient.postMessage).to.have.been.calledWith({
+      channel: orgByOrgTrue.getConfig().slack.channel,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: ' INITIAL_MESSAGE',
+          },
+        },
+      ],
+    });
+    expect(mockSlackClient.postMessage).to.have.been.calledWith({
+      channel: org2ByOrgTrue.getConfig().slack.channel,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: 'INITIAL_MESSAGE',
+          },
+        },
+      ],
+    });
+    const siteByOrgTrueSlackContext = {
+      channel: orgByOrgTrue.getConfig().slack.channel,
+      mentions: [],
+    };
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: siteByOrgTrueSlackContext,
+      message: siteByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: { thread_ts: 'thread-id', channel: orgByOrgTrue.getConfig().slack.channel },
+      message: site2ByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: { thread_ts: 'thread-id', channel: org2ByOrgTrue.getConfig().slack.channel },
+      message: site3ByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(context.log.error).to.have.been.calledOnceWith('Failed to send initial Slack message for https://abcd.com to '
+      + `${JSON.stringify(siteByOrgTrueSlackContext)}. Reason: Failed to send initial message`);
   });
 
   it('should continue with the other sites/orgs when the sendReport function throws an error', async () => {
+    mockDataAccess.getOrganizations.resolves([orgByOrgFalse]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits
+      .resolves([siteByOrgFalse, site2ByOrgFalse]);
+    processLatestAudit.withArgs(context, siteByOrgFalse, siteByOrgFalse.getAudits())
+      .returns(siteByOrgFalse.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site2ByOrgFalse, site2ByOrgFalse.getAudits())
+      .returns(site2ByOrgFalse.getAudits()[0].state.auditResult);
+    mockSlackClient.postMessage.resolves({ threadId: 'thread-id' });
+    sendReport.onFirstCall().rejects(new Error('Failed to send report'));
+
+    const response = await externalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(sendReport).to.have.been.calledTwice;
+    const siteByOrgFalseSlackContext = {
+      channel: siteByOrgFalse.getConfig().slack.channel,
+      mentions: siteByOrgFalse.getConfig().alerts[0].mentions[0].slack,
+    };
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: siteByOrgFalseSlackContext,
+      message: siteByOrgFalse.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: {
+        channel: site2ByOrgFalse.getConfig().slack.channel,
+        mentions: '',
+      },
+      message: site2ByOrgFalse.getAudits()[0].state.auditResult,
+    });
+    expect(context.log.error).to.have.been.calledOnceWith('Failed to send Slack message for https://foo.bar.com to '
+      + `${JSON.stringify(siteByOrgFalseSlackContext)}. Reason: Failed to send report`);
   });
 
   it('should use slack in site config to send initial message and report when alert is byOrg false', async () => {
+    mockDataAccess.getOrganizations.resolves([orgByOrgFalse]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits
+      .resolves([siteByOrgFalse, site2ByOrgFalse]);
+    processLatestAudit.withArgs(context, siteByOrgFalse, siteByOrgFalse.getAudits())
+      .returns(siteByOrgFalse.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site2ByOrgFalse, site2ByOrgFalse.getAudits())
+      .returns(site2ByOrgFalse.getAudits()[0].state.auditResult);
+    mockSlackClient.postMessage.resolves({ threadId: 'thread-id' });
+
+    const response = await externalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockSlackClient.postMessage).to.not.have.been.called;
+    expect(sendReport).to.have.been.calledTwice;
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: {
+        channel: siteByOrgFalse.getConfig().slack.channel,
+        mentions: siteByOrgFalse.getConfig().alerts[0].mentions[0].slack,
+      },
+      message: siteByOrgFalse.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: {
+        channel: site2ByOrgFalse.getConfig().slack.channel,
+        mentions: '',
+      },
+      message: site2ByOrgFalse.getAudits()[0].state.auditResult,
+    });
+    expect(context.log.error).not.to.have.been.called;
   });
 
   it('should use slack in org config to send initial message and report when alert is byOrg true', async () => {
-  });
+    mockDataAccess.getOrganizations.resolves([orgByOrgTrue, org2ByOrgTrue]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits.withArgs(orgByOrgTrue.getId(), 'broken-backlinks', false)
+      .resolves([siteByOrgTrue, site2ByOrgTrue]);
+    mockDataAccess.getSitesByOrganizationIDWithLatestAudits.withArgs(org2ByOrgTrue.getId(), 'broken-backlinks', false)
+      .resolves([site3ByOrgTrue]);
+    processLatestAudit.withArgs(context, siteByOrgTrue, siteByOrgTrue.getAudits())
+      .returns(siteByOrgTrue.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site2ByOrgTrue, site2ByOrgTrue.getAudits())
+      .returns(site2ByOrgTrue.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site3ByOrgTrue, site3ByOrgTrue.getAudits())
+      .returns(site3ByOrgTrue.getAudits()[0].state.auditResult);
+    mockSlackClient.postMessage.resolves({ threadId: 'thread-id' });
 
-  it('should send initial message only once per each organization', async () => {
-  });
+    const response = await externalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
 
-  it('should pass message returned by processLatestAudit to sendReport', async () => {
+    expect(response.status).to.equal(204);
+    expect(mockSlackClient.postMessage).to.have.been.calledTwice;
+    expect(mockSlackClient.postMessage).to.have.been.calledWith({
+      channel: orgByOrgTrue.getConfig().slack.channel,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: ' INITIAL_MESSAGE',
+          },
+        },
+      ],
+    });
+    expect(mockSlackClient.postMessage).to.have.been.calledWith({
+      channel: org2ByOrgTrue.getConfig().slack.channel,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: 'INITIAL_MESSAGE',
+          },
+        },
+      ],
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: { thread_ts: 'thread-id', channel: orgByOrgTrue.getConfig().slack.channel },
+      message: siteByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: { thread_ts: 'thread-id', channel: orgByOrgTrue.getConfig().slack.channel },
+      message: site2ByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: { thread_ts: 'thread-id', channel: org2ByOrgTrue.getConfig().slack.channel },
+      message: site3ByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(context.log.error).not.to.have.been.called;
   });
 });

--- a/test/digest/handler-internal.test.js
+++ b/test/digest/handler-internal.test.js
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+
+import sinon from 'sinon';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import { BaseSlackClient } from '@adobe/spacecat-shared-slack-client';
+import { createSite } from '@adobe/spacecat-shared-data-access/src/models/site.js';
+import internalDigestHandler from '../../src/digest/handler-internal.js';
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+const sandbox = sinon.createSandbox();
+
+describe('internal handler', () => {
+  let context;
+  let mockDataAccess;
+  let mockSlackClient;
+  let processLatestAudit = sandbox.stub();
+  let sendReport = sandbox.stub();
+
+  const siteByOrgTrue = createSite({
+    id: 'site-with-alert-config-org-level',
+    baseURL: 'https://abcd.com',
+    organizationId: 'org1',
+    config: {
+      alerts: [
+        {
+          type: '404',
+        },
+        {
+          type: 'broken-backlinks',
+        },
+      ],
+      slack: {},
+    },
+  });
+  siteByOrgTrue.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [
+          {
+            title: 'backlink title',
+            url_from: 'https://from.com/from-1',
+            url_to: 'https://www.abcd.com/to-1',
+          },
+          {
+            title: 'backlink title 2',
+            url_from: 'https://from.com/from-2',
+            url_to: 'https://www.abcd.com/to-2',
+          },
+        ],
+        finalUrl: 'www.abcd.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+  const site2ByOrgTrue = createSite({
+    id: 'site2-with-alert-config-org-level',
+    baseURL: 'https://xyz.com',
+    organizationId: 'org1',
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+        },
+      ],
+      slack: {},
+    },
+  });
+  site2ByOrgTrue.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [],
+        finalUrl: 'xyz.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+  const site3ByOrgTrue = createSite({
+    id: 'site3-with-alert-config-org-level',
+    baseURL: 'https://test.com',
+    organizationId: 'org2',
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+        },
+      ],
+      slack: {},
+    },
+  });
+  site3ByOrgTrue.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [],
+        finalUrl: 'test.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+
+  const siteByOrgFalse = createSite({
+    id: 'site-with-alert-config-site-level',
+    baseURL: 'https://foo.bar.com',
+    organizationId: 'org2',
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+          mentions: [
+            {
+              slack: [
+                '<@U04N8J8FL6H>',
+              ],
+            },
+          ],
+        },
+      ],
+      slack: {
+        channel: 'C06CNBHRH12',
+      },
+    },
+  });
+  siteByOrgFalse.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [
+          {
+            title: 'backlink title',
+            url_from: 'https://from.com/from-1',
+            url_to: 'https://foo.bar.com/to-1',
+          },
+        ],
+        finalUrl: 'foo.bar.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+  const site2ByOrgFalse = createSite({
+    id: 'site2-with-alert-config-site-level',
+    baseURL: 'https://bar.com',
+    organizationId: 'org2',
+    config: {
+      alerts: [
+        {
+          type: 'broken-backlinks',
+        },
+      ],
+      slack: {
+        channel: 'C06CNBHRH21',
+      },
+    },
+  });
+  site2ByOrgFalse.setAudits([{
+    state: {
+      auditResult: {
+        brokenBacklinks: [],
+        finalUrl: 'bar.com',
+        fullAuditRef: 'https://audit-ref.com/full-audit-ref',
+      },
+    },
+  }]);
+
+  beforeEach('setup', () => {
+    mockDataAccess = {
+      getSitesWithLatestAudit: sandbox.stub(),
+    };
+    mockSlackClient = {
+      postMessage: sandbox.stub(),
+    };
+    context = {
+      log: {
+        error: sandbox.stub(),
+      },
+      dataAccess: mockDataAccess,
+      slackClients: {
+        WORKSPACE_INTERNAL_STANDARD: mockSlackClient,
+      },
+      env: { AUDIT_REPORT_SLACK_CHANNEL_ID: 'internal-channel-id' },
+    };
+    sandbox.stub(BaseSlackClient, 'createFrom').returns(mockSlackClient);
+    processLatestAudit = sandbox.stub();
+    sendReport = sandbox.stub();
+  });
+
+  afterEach('clean', () => {
+    sandbox.restore();
+  });
+
+  it('should skip the site if it does not have any audits', async () => {
+    mockDataAccess.getSitesWithLatestAudit.resolves([{
+      getAudits: () => [],
+    }]);
+
+    const response = await internalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockDataAccess.getSitesWithLatestAudit).to.have.been.calledOnceWith('broken-backlinks', false);
+    expect(processLatestAudit).not.to.have.been.called;
+    expect(mockSlackClient.postMessage).not.to.have.been.called;
+    expect(sendReport).not.to.have.been.called;
+    expect(context.log.error).not.to.have.been.called;
+  });
+
+  it('should skip the site if processLatestAudit function does not return any message', async () => {
+    mockDataAccess.getSitesWithLatestAudit.resolves([siteByOrgTrue]);
+    processLatestAudit.withArgs(context, siteByOrgTrue, siteByOrgTrue.getAudits()).returns({});
+
+    const response = await internalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockDataAccess.getSitesWithLatestAudit).to.have.been.calledOnceWith('broken-backlinks', false);
+    expect(mockSlackClient.postMessage).not.to.have.been.called;
+    expect(sendReport).not.to.have.been.called;
+    expect(context.log.error).not.to.have.been.called;
+  });
+
+  it('should continue with the other sites/orgs when the sendInitialMessage function throws an error', async () => {
+    mockDataAccess.getSitesWithLatestAudit.withArgs('broken-backlinks', false)
+      .resolves([siteByOrgTrue, site2ByOrgTrue, site3ByOrgTrue]);
+    processLatestAudit.withArgs(context, siteByOrgTrue, siteByOrgTrue.getAudits())
+      .returns(siteByOrgTrue.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site2ByOrgTrue, site2ByOrgTrue.getAudits())
+      .returns(site2ByOrgTrue.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site3ByOrgTrue, site3ByOrgTrue.getAudits())
+      .returns(site3ByOrgTrue.getAudits()[0].state.auditResult);
+    mockSlackClient.postMessage.onFirstCall().rejects(new Error('Failed to send initial message'));
+    mockSlackClient.postMessage.onSecondCall().resolves({ threadId: 'thread-id' });
+
+    const response = await internalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(mockSlackClient.postMessage).to.have.been.calledTwice;
+    expect(mockSlackClient.postMessage).to.have.been.calledWith({
+      channel: context.env.AUDIT_REPORT_SLACK_CHANNEL_ID,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: 'INITIAL_MESSAGE',
+          },
+        },
+      ],
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: {},
+      message: siteByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: { thread_ts: 'thread-id', channel: context.env.AUDIT_REPORT_SLACK_CHANNEL_ID },
+      message: site2ByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: { thread_ts: 'thread-id', channel: context.env.AUDIT_REPORT_SLACK_CHANNEL_ID },
+      message: site3ByOrgTrue.getAudits()[0].state.auditResult,
+    });
+    expect(context.log.error).to.have.been.calledOnceWith('Failed to send initial Slack message for https://abcd.com to {}. '
+      + 'Reason: Failed to send initial message');
+  });
+
+  it('should continue with the other sites/orgs when the sendReport function throws an error', async () => {
+    mockDataAccess.getSitesWithLatestAudit
+      .resolves([siteByOrgFalse, site2ByOrgFalse]);
+    processLatestAudit.withArgs(context, siteByOrgFalse, siteByOrgFalse.getAudits())
+      .returns(siteByOrgFalse.getAudits()[0].state.auditResult);
+    processLatestAudit.withArgs(context, site2ByOrgFalse, site2ByOrgFalse.getAudits())
+      .returns(site2ByOrgFalse.getAudits()[0].state.auditResult);
+    mockSlackClient.postMessage.resolves({ threadId: 'thread-id', channel: context.env.AUDIT_REPORT_SLACK_CHANNEL_ID });
+    sendReport.onFirstCall().rejects(new Error('Failed to send report'));
+
+    const response = await internalDigestHandler(context, 'broken-backlinks', 'INITIAL_MESSAGE', processLatestAudit, sendReport);
+
+    expect(response.status).to.equal(204);
+    expect(sendReport).to.have.been.calledTwice;
+    const initialSlackContext = {
+      thread_ts: 'thread-id',
+      channel: context.env.AUDIT_REPORT_SLACK_CHANNEL_ID,
+    };
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: initialSlackContext,
+      message: siteByOrgFalse.getAudits()[0].state.auditResult,
+    });
+    expect(sendReport).to.have.been.calledWith({
+      slackClient: mockSlackClient,
+      slackContext: {
+        channel: context.env.AUDIT_REPORT_SLACK_CHANNEL_ID,
+        thread_ts: 'thread-id',
+      },
+      message: site2ByOrgFalse.getAudits()[0].state.auditResult,
+    });
+    expect(context.log.error).to.have.been.calledOnceWith('Failed to send Slack message for https://foo.bar.com to '
+      + `${JSON.stringify(initialSlackContext)}. Reason: Failed to send report`);
+  });
+});

--- a/test/experimentation/handler.test.js
+++ b/test/experimentation/handler.test.js
@@ -118,14 +118,14 @@ describe('experimentation handler', () => {
   it('throws error when slack api fails to upload file', async () => {
     context.slackClients.WORKSPACE_INTERNAL_STANDARD.fileUpload.rejects(new Error('error'));
     const resp = await experimentationHandler(message, context);
-    expect(resp.status).to.equal(204);
+    expect(resp.status).to.equal(500);
     expect(mockLog.error).to.have.been.calledOnce;
   });
 
   it('throws error when slack api fails to upload file', async () => {
     context.slackClients.WORKSPACE_INTERNAL_STANDARD.fileUpload.rejects(new Error('error'));
     const resp = await experimentationHandler(message, context);
-    expect(resp.status).to.equal(204);
+    expect(resp.status).to.equal(500);
     expect(mockLog.error).to.have.been.calledOnce;
   });
 });

--- a/test/notfound/handler-external.test.js
+++ b/test/notfound/handler-external.test.js
@@ -169,39 +169,6 @@ describe('not found external handler', () => {
     expect(resp.status).to.equal(204);
   });
 
-  it('builds no message when there is no audit', async () => {
-    context.slackClients = {
-      WORKSPACE_EXTERNAL_STANDARD: { postMessage: sandbox.stub().resolves() },
-    };
-    const noAuditContext = { ...context };
-    noAuditContext.dataAccess = { ...context.dataAccess };
-    noAuditContext.dataAccess.getSitesByOrganizationIDWithLatestAudits = () => [];
-    const resp = await notFoundExternalDigestHandler({}, noAuditContext);
-    expect(resp.status).to.equal(204);
-  });
-
-  it('returns 500 if the initial slack api fails', async () => {
-    context.slackClients = {
-      WORKSPACE_EXTERNAL_STANDARD: { postMessage: sandbox.stub().rejects(new Error('error')) },
-    };
-    const resp = await notFoundExternalDigestHandler({}, context);
-    expect(resp.status).to.equal(500);
-  });
-
-  it('continues if just one slack api call failed', async () => {
-    const channel = 'channel1';
-    context.rumApiClient = {
-      create404Backlink: sandbox.stub().resolves(backlink),
-    };
-    context.slackClients = {
-      WORKSPACE_EXTERNAL_STANDARD: { postMessage: sandbox.stub().onFirstCall().resolves({ channel, ts: 'ts-1' }) },
-    };
-    context.slackClients.WORKSPACE_EXTERNAL_STANDARD.postMessage.onSecondCall().rejects(new Error('error'));
-
-    const resp = await notFoundExternalDigestHandler({}, context);
-    expect(resp.status).to.equal(204);
-  });
-
   it('builds and sends the slack message when there is an site config and a 404 audit stored for the site and no backlink', async () => {
     const channel = 'channel1';
     context.rumApiClient = {

--- a/test/notfound/handler-internal.test.js
+++ b/test/notfound/handler-internal.test.js
@@ -95,34 +95,7 @@ describe('not found internal handler', () => {
       },
     };
     const resp = await notFoundInternalDigestHandler({}, context);
-    expect(resp.status).to.equal(204);
-  });
 
-  it('continues if just one slack api call failed', async () => {
-    context.rumApiClient = {
-      create404Backlink: sandbox.stub().resolves(backlink),
-      getDomainList: sandbox.stub().resolves(['abcd.com']),
-    };
-    context.slackClients = {
-      WORKSPACE_INTERNAL_STANDARD: {
-        postMessage: sandbox.stub().onFirstCall().resolves(
-          { channelId: channel, threadId: thread },
-        ),
-      },
-    };
-    context.slackClients.WORKSPACE_INTERNAL_STANDARD.postMessage.onSecondCall().rejects(new Error('error'));
-    const resp = await notFoundInternalDigestHandler({}, context);
     expect(resp.status).to.equal(204);
-  });
-
-  it('returns 500 if the initial slack api fails', async () => {
-    context.rumApiClient = {
-      getDomainList: sandbox.stub().resolves(['abcd.com']),
-    };
-    context.slackClients = {
-      WORKSPACE_INTERNAL_STANDARD: { postMessage: sandbox.stub().onFirstCall().rejects(new Error('error')) },
-    };
-    const resp = await notFoundInternalDigestHandler({}, context);
-    expect(resp.status).to.equal(500);
   });
 });

--- a/test/support/slack.test.js
+++ b/test/support/slack.test.js
@@ -57,7 +57,7 @@ describe('slack api', () => {
       .reply(200, 'invalid-json');
 
     await expect(postSlackMessage(token, opts))
-      .to.be.rejectedWith('Failed to send slack message. Status: 200');
+      .to.be.rejectedWith('Failed to send slack message on channel channel-id. Status: 200');
   });
 
   it('rejects when slack api returns error', async () => {
@@ -149,7 +149,7 @@ describe('slack api', () => {
       channel: 'channel-id',
     };
 
-    await expect(uploadSlackFile(token, options)).to.be.rejectedWith('Failed to upload file to slack. Reason: Slack upload file API request failed. Status: 500');
+    await expect(uploadSlackFile(token, options)).to.be.rejectedWith('Failed to upload file to slack: channel channel-id, filename test-file.csv. Reason: Slack upload file API request failed. Status: 500');
   });
 
   it('throws error when slack api request is not acknowledged', async () => {
@@ -190,6 +190,6 @@ describe('slack api', () => {
       channel: 'channel-id',
     };
 
-    await expect(uploadSlackFile(token, options)).to.be.rejectedWith('Failed to upload file to slack. Reason: Failed to parse Slack API response. Error: SyntaxError: Unexpected token \'i\', "invalid" is not valid JSON');
+    await expect(uploadSlackFile(token, options)).to.be.rejectedWith('Failed to upload file to slack: channel channel-id, filename test-file.csv. Reason: Failed to parse Slack API response. Error: SyntaxError: Unexpected token \'i\', "invalid" is not valid JSON');
   });
 });


### PR DESCRIPTION
Fix https://github.com/adobe/spacecat-audit-post-processor/issues/136
Fix https://github.com/adobe/spacecat-audit-post-processor/issues/132
Added separate unit tests for the external and internal digest handler, fully covering their functionality and the fixes
Improved logging